### PR TITLE
Revamp splunkf

### DIFF
--- a/splunk_setup/build.sh
+++ b/splunk_setup/build.sh
@@ -1,35 +1,48 @@
 #!/bin/bash
-indexes=('misc' 'service_auth' 'service')
-echo "Run this script as root, exit and rerun if not root user. Script will begin in 3 seconds"
-sleep 3
-spl_url="https://download.splunk.com/products/splunk/releases/9.0.4.1/linux/splunk-9.0.4.1-419ad9369127-linux-2.6-amd64.deb"
-if apt list | grep -q 'wget'; then 
-    wget -O splunk.deb $spl_url
-else
-    curl -o splunk.deb $spl_url    
-fi
-echo "Grabbing splunk install"
-echo "Currently Installing Splunk, please wait at least 2-3 minutes for completion"
-sudo dpkg -i ./splunk.deb
-echo "Installation should be done"
-echo "alias splunk='/opt/splunk/bin/splunk'" >> ~/.bashrc
-reset
-sleep 3
-echo "****** Starting Splunk ******"
-# needed here since we will disable root after the script is run
-# and it gives us full access over splunk
-if id "CCDCUser1" >/dev/null 2>&1; then
+function build_indexer {
+    indexes=('misc' 'service_auth' 'service')
+    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUserXX). Script will begin in 3 seconds"
+    sleep 3
+    spl_url="https://download.splunk.com/products/splunk/releases/9.0.4.1/linux/splunk-9.0.4.1-419ad9369127-linux-2.6-amd64.deb"
+    echo "############# Installing Splunk #############"
+    if [[ ! -d /opt/splunk ]]; then
+        if command -v wget &> /dev/null; then
+            wget -O splunk.deb $spl_url
+        else
+            curl -o splunk.deb $spl_url
+        fi
+        sudo dpkg -i ./splunk.deb
+        echo "############# Starting Splunk #############"
+        echo "Starting up splunk. Please set name to.....you know and the password to....you know"
+        sudo /opt/splunk/bin/splunk start --accept-license
+    else
+        echo "Install already exists. Proceeding to configure indexer"
+        echo "Verifying Splunk. If prompted, please set username to.....you know and the password to....you know"
+        sudo /opt/splunk/bin/splunk start --accept-license
+    fi
     sudo chown -R CCDCUser1 /opt/splunk
     sudo chgrp -R CCDCUser1 /opt/splunk
-else
-    sudo useradd CCDCUser1
-    sudo usermod -aG sudo
-    sudo chown -R CCDCUser1 /opt/splunk
-    sudo chgrp -R CCDCUser1 /opt/splunk
-fi
-echo "****** Adding Indexes to Splunk ******"
-for i in "${indexes[@]}"; do
-    sudo /opt/splunk/bin/splunk add index $i
-done
-echo "Starting up splunk. Please set name to.....you know and the password to....you know"
-sudo /opt/splunk/bin/splunk start --accept-license
+    echo "############# Adding Splunk Indexes #############"
+    sudo /opt/splunk/bin/splunk enable listen 9997
+    for i in "${indexes[@]}"; do
+        sudo /opt/splunk/bin/splunk add index "$i"
+    done
+    echo "############# Installing Searches #############"
+    wget https://raw.githubusercontent.com/BYU-CCDC/public-ccdc-resources/main/splunk_setup/savedsearches.conf
+    sudo mkdir -p /opt/splunk/etc/users/splunk/search/local/
+    sudo cp /opt/splunk/etc/users/splunk/search/local/savedsearches.conf /opt/splunk/etc/users/splunk/search/local/savedsearches.bk
+    sudo mv ./savedsearches.conf /opt/splunk/etc/users/splunk/search/local/savedsearches.conf
+    sudo /opt/splunk/bin/splunk restart
+
+}
+
+function check_user {
+    if [[ "$(whoami)" != "CCDCUser1" && "$(whoami)" != "CCDCUser2" ]]; then
+        echo "Please run this with our privileged user CCDCUser1 or CCDCUser2"
+        exit 1
+    fi
+}
+
+################## MAIN ##################
+check_user
+build_indexer

--- a/splunk_setup/build.sh
+++ b/splunk_setup/build.sh
@@ -37,8 +37,8 @@ function build_indexer {
 }
 
 function check_user {
-    if [[ "$(whoami)" != "CCDCUser1" && "$(whoami)" != "CCDCUser2" ]]; then
-        echo "Please run this with our privileged user CCDCUser1 or CCDCUser2"
+    if [[ "$(whoami)" != "CCDCUser1" ]]; then
+        echo "Please run this with our privileged user"
         exit 1
     fi
 }

--- a/splunk_setup/build.sh
+++ b/splunk_setup/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 function build_indexer {
     indexes=('misc' 'service_auth' 'service')
-    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUserXX). Script will begin in 3 seconds"
+    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUser1). Script will begin in 3 seconds"
     sleep 3
     spl_url="https://download.splunk.com/products/splunk/releases/9.0.4.1/linux/splunk-9.0.4.1-419ad9369127-linux-2.6-amd64.deb"
     echo "############# Installing Splunk #############"

--- a/splunk_setup/savedsearches.conf
+++ b/splunk_setup/savedsearches.conf
@@ -1,0 +1,123 @@
+# [<search_name>]
+# action.webhook.enable_allowlist = 0
+# alert.suppress = 0
+# alert.track = 1
+# counttype = number of events
+# cron_schedule = */15 * * * *
+# dispatch.earliest_time = -24h@h (this means the run every 24 hours at the top of the 24th hour)
+# dispatch.latest_time = now
+# display.general.type = statistics
+# display.page.search.tab = statistics
+# enableSched = 1
+# quantity = 0
+# relation = greater than
+# request.ui_dispatch_app = search
+# request.ui_dispatch_view = search
+# search = index=*\
+# | table host\
+# |table index
+
+[New Users - Linux]
+action.webhook.enable_allowlist = 0
+alert.suppress = 0
+alert.track = 1
+counttype = number of events
+cron_schedule = */15 * * * *
+dispatch.earliest_time = -60m@m
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+enableSched = 1
+quantity = 0
+relation = greater than
+request.ui_dispatch_app = search
+request.ui_dispatch_view = search
+search = index="service_auth"\
+| rex "new user: name=(?<new_user>[^,]+)" | where new_user != "CCDC*"\
+| stats count by new_user,_raw
+
+[High Failed Logins - Linux]
+action.webhook.enable_allowlist = 0
+alert.suppress = 0
+alert.track = 1
+counttype = number of events
+cron_schedule = */15 * * * *
+dispatch.earliest_time = -30m
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.mode = verbose
+display.page.search.tab = statistics
+enableSched = 1
+quantity = 0
+relation = greater than
+request.ui_dispatch_app = search
+request.ui_dispatch_view = search
+search = index="service_auth" failed password \
+| rex "Failed password for invalid user (?<fail_user>[^ ]+) from (?<ip>[^ ]+)" \
+| rex "message repeated (?<num_fails>[^ ]+) times: \[ Failed password for (?<fail_user>[^ ]+) from (?<ip2>[^ ]+)" \
+| eval ip=coalesce(ip, ip2) \
+| stats values(ip) as ip, sum(num_fails) as other_fails, count as fails by fail_user \
+| eval other_fails=if(isnull(other_fails), 0, other_fails) \
+| eval total_fails=fails+other_fails \
+| where total_fails > 3 \
+| table fail_user, ip, total_fails
+
+[Failed Logins - Windows]
+action.webhook.enable_allowlist = 0
+alert.suppress = 0
+alert.track = 1
+counttype = number of events
+cron_schedule = */15 * * * *
+dispatch.earliest_time = -60m@m
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+enableSched = 1
+quantity = 0
+relation = greater than
+request.ui_dispatch_app = search
+request.ui_dispatch_view = search
+search = index=service_auth source="WinEventLog:Security" EventCode=4625 \
+| stats count by Account_Name \
+| where count > 3
+
+[PS Activity]
+action.webhook.enable_allowlist = 0
+alert.suppress = 0
+alert.track = 1
+counttype = number of events
+cron_schedule = */15 * * * *
+dispatch.earliest_time = -60m@m
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+enableSched = 1
+quantity = 0
+relation = greater than
+request.ui_dispatch_app = search
+request.ui_dispatch_view = search
+search = index=service_auth EventCode=4104 ("PowerShell –Version" OR "-w hidden" OR "FromBase64String" OR "bypass -" OR "Invoke-") \
+| stats values(Path) as paths, values(Message) as outputs count by User 
+
+[Failed Logins Then Successful Login - Windows]
+action.webhook.enable_allowlist = 0
+alert.suppress = 0
+alert.track = 1
+counttype = number of events
+cron_schedule = */15 * * * *
+dispatch.earliest_time = -60m@m
+dispatch.latest_time = now
+display.general.type = statistics
+display.page.search.tab = statistics
+enableSched = 1
+quantity = 0
+relation = greater than
+request.ui_dispatch_app = search
+request.ui_dispatch_view = search
+search = index=service_auth EventCode=4625 OR EventCode=4624 NOT ("DWM*" OR "LOCAL SERVICE" OR "NETWORK SERVICE" OR "UMFD-*") \
+| eval fail=if(EventCode=4625, 1, 0) \
+| eval success=if(EventCode=4624, 1, 0) \
+| stats sum(fail) as fails, sum(success) as successes by Account_Name \
+| where fails > 6 and successes > 0 
+
+

--- a/splunk_setup/splunkf.sh
+++ b/splunk_setup/splunkf.sh
@@ -62,11 +62,7 @@ function add_monitors {
         if [ "$isFirst" = true ]; then
             isFirst=false # ignores the name of the index and only adds the logs sources
         else
-            if [ -e "$source" ]; then # checks is path exists
-                sudo /opt/splunkforwarder/bin/splunk add monitor "$source" -index "${log_sources[0]}"
-            else
-                echo "Path $source not found. Skipping......"
-            fi
+            sudo /opt/splunkforwarder/bin/splunk add monitor "$source" -index "${log_sources[0]}"
         fi
     done
 }
@@ -183,7 +179,7 @@ function add_mysql_logs {
 }
 
 function setup_forwarder {
-    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUserXX). Script will begin in 3 seconds"
+    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUser1). Script will begin in 3 seconds"
     sleep 3
     if [[ $2 == "" ]]; then 
         echo "Error please provide the IP of the central splunk instance"

--- a/splunk_setup/splunkf.sh
+++ b/splunk_setup/splunkf.sh
@@ -210,8 +210,8 @@ function setup_forwarder {
 }
 
 function check_user {
-    if [[ "$(whoami)" != "CCDCUser1" && "$(whoami)" != "CCDCUser2" ]]; then
-        echo "Please run this with our privileged user CCDCUser1 or CCDCUser2"
+    if [[ "$(whoami)" != "CCDCUser1" ]]; then
+        echo "Please run this with our privileged user"
         exit 1
     fi
 }

--- a/splunk_setup/splunkf.sh
+++ b/splunk_setup/splunkf.sh
@@ -13,155 +13,237 @@ sparcz="https://download.splunk.com/products/universalforwarder/releases/9.0.1/s
 sparcp5p="https://download.splunk.com/products/universalforwarder/releases/9.0.1/solaris/splunkforwarder-9.0.1-82c987350fde-solaris-sparc.p5p"
 aix="https://download.splunk.com/products/universalforwarder/releases/9.0.1/aix/splunkforwarder-9.0.1-82c987350fde-AIX-powerpc.tgz"
 
-echo "Run this script as root, exit and rerun if not root user. Script will begin in 3 seconds"
-sleep 3
-echo "Performing Setup"
-# this case statement handles command line arguments
-# for example if you wanted to install a forwarder for debian you would input:
-# ./splunkf.sh debian
-if [[ ! -d /opt/splunkforwarder ]]; then
-    case "$1" in
-        debian )
-            echo "******* Installing forwarder for Debian ********"
-            echo
-            sudo wget -O splunkf.deb "$deb"
-            sudo dpkg -i ./splunkf.deb
-        ;;
-        linux )
-            echo "******* Installing forwarder general tgz for linux *******"
-            echo
-            sudo wget -O splunkf.tgz "$linux"
-            sudo tar -xfvz splunkf.tgz -C /opt/
-        ;;
-        rpm )
-            echo "******* Installing forwarder for rpm based machines *******"
-            echo
-            sudo wget -O splunkf.rpm "$rpm"
-            sudo yum install ./splunkf.rpm -y
-        ;;
-        # prints the url in case there are problems with the install
-        -p)
-            case $2 in
-                debian)
-                    echo $deb
-                    exit
+###################### INDEXES ######################
+
+# In Bash 4.3.8, associative arrays were introduced, but they do not support nested structures directly so we have to be hacky about it to ensure older versions work
+# put name of index in the first [0] position
+# index names should correspond to line 1 in the build.sh script otherwise the splunk indexer will not recieve logs correctly
+service_indexes=( 'service' '/etc/services/' '/etc/init.d' '/var/log/apache/access.log' '/var/log/apache/error.log' '/var/log/mysql/error' '/var/www/' ) #service
+service_auth_indexes=( 'service_auth' '/var/log/auth.log' '/var/log/secure/' '/var/log/audit/audit.log' ) # service_auth
+misc_indexes=( 'misc' '/tmp' '/etc/passwd' ) # misc
+
+#####################################################
+
+function print_sources {
+    index=("$@")
+    isFirst=true
+    for value in "${index[@]}"; do
+        if [ "$isFirst" = true ]; then
+            isFirst=false # ignores the name of the index and only outputs the logs sources
+        else
+            options+="$value, "
+        fi
+    done
+    options=${options%, }  # Remove the trailing comma and space
+    echo "       -- $options"
+}
+
+function add_monitors {
+    log_sources=("$@")
+    isFirst=true
+    options=""
+    echo "Would you like to add additional log locations for index: ${log_sources[0]}"
+    echo "   -- Default log locations are:"
+    print_sources  "${log_sources[@]}"
+    read -r -p "(y/n): " option
+    option=$(echo "$option" | tr -d ' ') #truncates any spaces accidentally put in
+    l="true"
+    if [ "$option" == "y" ]; then
+        while [ "$l" != "false" ]; do
+            read -r -p "Enter additional logs sources for index: ${log_sources[0]} (one entry per line; hit enter to continue): " userInput
+            if [[ "$userInput" == "" ]]; then
+                l="false"
+            else
+                log_sources+=("$userInput")
+            fi
+        done
+    fi
+    echo "AFTER ADDING"
+    print_sources  "${log_sources[@]}"
+    isFirst=true
+    for source in "${log_sources[@]}"; do
+        if [ "$isFirst" = true ]; then
+            isFirst=false # ignores the name of the index and only adds the logs sources
+        else
+            if [ -e "$source" ]; then # checks is path exists
+                sudo /opt/splunkforwarder/bin/splunk add monitor "$source" -index "${log_sources[0]}"
+            else
+                echo "Path $source not found. Skipping......"
+            fi
+        fi
+    done
+}
+
+function install_forwarder {
+    if [[ ! -d /opt/splunkforwarder ]]; then
+        case "$1" in
+            debian )
+                echo "******* Installing forwarder for Debian ********"
+                echo
+                sudo wget -O splunkf.deb "$deb"
+                sudo dpkg -i ./splunkf.deb
+            ;;
+            linux )
+                echo "******* Installing generic forwarder(.tgz) for linux *******"
+                echo
+                sudo wget -O splunkf.tgz "$linux"
+                sudo tar -xfvz splunkf.tgz -C /opt/
+            ;;
+            rpm )
+                echo "******* Installing forwarder for rpm based machines *******"
+                echo
+                sudo wget -O splunkf.rpm "$rpm"
+                sudo yum install ./splunkf.rpm -y
+            ;;
+            # prints the url in case there are problems with the install
+            -p)
+                case $2 in
+                    debian)
+                        echo $deb
+                        exit
+                    ;;
+                    rpm)
+                        echo $rpm
+                        exit
+                    ;;
+                    linux)
+                        echo $linux
+                        exit
+                    ;;
+                    *)
+                        echo "url not found"
+                        exit
+                    ;;
+                esac
+            ;;
+            # prints urls of the lesser known/used splunk forwarders
+            other )
+                echo "Linux ARM: $arm"
+                echo 
+                echo "Linux s390: $s90"
+                echo
+                echo "Linux PPCLE: $ppcle"
+                echo
+                echo "OSX M1/Intel: $mac"
+                echo
+                echo "FreeBSD: $freebsd"
+                echo
+                echo "Solaris:
+                - .Z (64-bit): $z
+                - .p5p (64-bit): $p5p
+                - Sparc .Z: $sparcz
+                - Sparc .p5p: $sparcp5p"
+                echo
+                echo "AIX: $aix"
+                exit
+            ;;
+            # catch all statement that provides the user with a list of potential command line options
+            *)
+                echo "Usage: ./splunkf.sh <option> <forward-server-ip>"
+                echo "OPTIONS:
+                    -> debian
+                    -> linux (general tgz file)
+                    -> rpm
+                    -> other (shows list of other forwarder urls)
+                    -> -p (prints the specified url debian, linux or rpm in case something is not working)
+                    "
+                exit
                 ;;
-                rpm)
-                    echo $rpm
-                    exit
-                ;;
-                linux)
-                    echo $linux
-                    exit
-                ;;
-                *)
-                    echo "url not found"
-                    exit
-                ;;
-            esac
-        ;;
-        # prints urls of the lesser known/used splunk forwarders
-        other )
-            echo "Linux ARM: $arm"
-            echo 
-            echo "Linux s390: $s90"
-            echo
-            echo "Linux PPCLE: $ppcle"
-            echo
-            echo "OSX M1/Intel: $mac"
-            echo
-            echo "FreeBSD: $freebsd"
-            echo
-            echo "Solaris:
-            - .Z (64-bit): $z
-            - .p5p (64-bit): $p5p
-            - Sparc .Z: $sparcz
-            - Sparc .p5p: $sparcp5p"
-            echo
-            echo "AIX: $aix"
-            exit
-        ;;
-        # catch all statement that provides the user with a list of potential command line options
-        *)
-            echo "Usage: ./splunkf.sh <option> <forward-server-ip>"
-            echo "OPTIONS:
-                -> debian
-                -> linux (general tgz file)
-                -> rpm
-                -> other (shows list of other forwarder urls)
-                -> -p (prints the specified url debian, linux or rpm in case something is not working)
-                "
-            exit
-        ;;
-    esac
-else
-    echo "Install already exists. Proceeding to configure forwarder"
-fi
-if [[ $2 == "" ]]; then 
-    echo "Error please provide the IP of the central splunk instance"
-    exit
-fi
-echo "****** Starting Splunk ******"
-# needed here since we will disable root after the script is run
-# and it gives us full access over splunk
-if id "CCDCUser1" >/dev/null 2>&1; then
-    sudo chown -R CCDCUser1 /opt/splunkforwarder
+        esac
+    else
+            echo "Install already exists. Proceeding to configure forwarder"
+    fi
+}
+
+
+function add_mysql_logs {
+    if [ -d "/etc/mysql/my.cnf" ]; then
+        MYSQL_CONFIG="/etc/mysql/my.cnf"  # Adjust the path based on your system
+
+        # Log file paths
+        GENERAL_LOG="/var/log/mysql/mysql.log"
+        ERROR_LOG="/var/log/mysql/error.log"
+
+        # Enable General Query Log
+        echo "[mysqld]" >> "$MYSQL_CONFIG"
+        echo "general_log = 1" >> "$MYSQL_CONFIG"
+        echo "general_log_file = $GENERAL_LOG" >> "$MYSQL_CONFIG"
+
+        # Enable Error Log
+        echo "log_error = $ERROR_LOG" >> "$MYSQL_CONFIG"
+
+        # Restart MySQL service
+        if command -v systemctl &> /dev/null; then
+            sudo systemctl restart mysql
+        elif command -v service &> /dev/null; then
+            sudo service mysql restart
+        else
+            echo "Error: Unable to restart MySQL. Please restart the MySQL service manually."
+        fi
+    else
+        echo "ERROR: Could not find correct mysql log"
+    fi
+}
+
+function setup_forwarder {
+    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUserXX). Script will begin in 3 seconds"
+    sleep 3
+    if [[ $2 == "" ]]; then 
+        echo "Error please provide the IP of the central splunk instance"
+        echo "Usage: ./splunkf.sh <option> <forward-server-ip>"
+        exit
+    fi
+    echo "############# Beginning Forwarder Install #############"
+    install_forwarder "$1" "$2"
+    sudo chown -R CCDCUser1 /opt/splunkforwarder #give privs to our user
     sudo chgrp -R CCDCUser1 /opt/splunkforwarder
-else
-    sudo useradd CCDCUser1
-    sudo usermod -aG sudo
-    sudo chown -R CCDCUser1 /opt/splunkforwarder
-    sudo chgrp -R CCDCUser1 /opt/splunkforwarder
-fi
-sudo /opt/splunkforwarder/bin/splunk start --accept-license
+    sudo /opt/splunkforwarder/bin/splunk start --accept-license
 
-echo "Beginning to run configuration adjustments"
-# enables logging in mysql
-path=""
-if [[ -d /etc/mysql ]]; then
-    if [[ -f /etc/alternatives/my.cnf ]]; then
-        path="/etc/alternatives/my.cnf"
-    else
-        path="/etc/mysql/my.cnf"
+    echo "############# Adding Monitors #############"
+    add_monitors "${misc_indexes[@]}"
+    add_monitors "${service_auth_indexes[@]}"
+    add_monitors "${service_indexes[@]}"
+    add_mysql_logs
+
+    echo "############# Adding Forward Server #############*"
+    sudo /opt/splunkforwarder/bin/splunk add forward-server $2:9997
+    echo "############# Restarting Splunk #############*"
+    sudo /opt/splunkforwarder/bin/splunk restart
+
+}
+
+function setup_fim {
+    monitors=('/etc/passwd' '/etc/group' '/etc/sudoers')
+    options=""
+    echo "Would you like to add additional log locations for FIM:"
+    echo "   -- Default log locations are:"
+    print_sources  "${monitors[@]}"
+    read -r -p "(y/n): " option
+    option=$(echo "$option" | tr -d ' ') #truncates any spaces accidentally put in
+    l="true"
+    if [ "$option" == "y" ]; then
+        while [ "$l" != "false" ]; do
+            read -r -p "Enter additional files/dirs to monitor (one entry per line; hit enter to continue): " userInput
+            if [[ "$userInput" == "" ]]; then
+                l="false"
+            else
+                log_sources+=("$userInput")
+            fi
+        done
     fi
-    sudo echo "[mysqld_safe]
-    log_error=/var/log/mysql/mysql_error.log
+    # TODO: Build out FIM with auditd. Add audit log to splunk 
+    # https://docs.rapid7.com/insightidr/fim-for-linux/
+    # https://uit.stanford.edu/service/ossec/install-source
+}
 
-    [mysqld]
-    log_error=/var/log/mysql/mysql_error.log" >> $path
-    echo "***** Attempting to restart mysql *******"
-    service mysql restart 
-fi
-
-# these are separated in order to use indexes in splunk which increases searchability and organization
-services=( '/etc/services/' '/etc/init.d' '/var/log/apache/access.log' '/var/log/apache/error.log' '/var/log/mysql/error' '/var/www/')
-logs=('/var/log/auth.log' '/var/log/secure/' '/var/log/audit/audit.log')
-misc=('/tmp' '/etc/passwd')
-
-for i in "${services[@]}"; do
-    if [[ -f $i || -d $i ]]; then
-        sudo /opt/splunkforwarder/bin/splunk add monitor $i -index "service"
-    else
-        echo "$i does not exist"
+function check_user {
+    if [[ "$(whoami)" != "CCDCUser1" && "$(whoami)" != "CCDCUser2" ]]; then
+        echo "Please run this with our privileged user CCDCUser1 or CCDCUser2"
+        exit 1
     fi
-done
+}
 
-for i in "${logs[@]}"; do
-    if [[ -f $i || -d $i ]]; then
-        sudo /opt/splunkforwarder/bin/splunk add monitor $i -index "service_auth"
-    else
-        echo "$i does not exist"
-    fi
-done
-
-for i in "${misc[@]}"; do
-    if [[ -f $i || -d $i ]]; then
-        sudo /opt/splunkforwarder/bin/splunk add monitor $i -index "misc"
-    else
-        echo "$i does not exist"
-    fi
-done
-echo "****** Adding Forward Server *******"
-sudo /opt/splunkforwarder/bin/splunk add forward-server $2:9997
-echo "****** Restarting Splunk *******"
-sudo /opt/splunkforwarder/bin/splunk restart
+################################# MAIN #################################
+check_user
+setup_forwarder "$1" "$2"
+############################### END MAIN ###############################

--- a/splunk_setup/splunkf.sh
+++ b/splunk_setup/splunkf.sh
@@ -12,7 +12,6 @@ p5p="https://download.splunk.com/products/universalforwarder/releases/9.0.1/sola
 sparcz="https://download.splunk.com/products/universalforwarder/releases/9.0.1/solaris/splunkforwarder-9.0.1-82c987350fde-SunOS-sparc.tar.Z"
 sparcp5p="https://download.splunk.com/products/universalforwarder/releases/9.0.1/solaris/splunkforwarder-9.0.1-82c987350fde-solaris-sparc.p5p"
 aix="https://download.splunk.com/products/universalforwarder/releases/9.0.1/aix/splunkforwarder-9.0.1-82c987350fde-AIX-powerpc.tgz"
-
 ###################### INDEXES ######################
 
 # In Bash 4.3.8, associative arrays were introduced, but they do not support nested structures directly so we have to be hacky about it to ensure older versions work
@@ -58,8 +57,6 @@ function add_monitors {
             fi
         done
     fi
-    echo "AFTER ADDING"
-    print_sources  "${log_sources[@]}"
     isFirst=true
     for source in "${log_sources[@]}"; do
         if [ "$isFirst" = true ]; then
@@ -210,30 +207,6 @@ function setup_forwarder {
     echo "############# Restarting Splunk #############*"
     sudo /opt/splunkforwarder/bin/splunk restart
 
-}
-
-function setup_fim {
-    monitors=('/etc/passwd' '/etc/group' '/etc/sudoers')
-    options=""
-    echo "Would you like to add additional log locations for FIM:"
-    echo "   -- Default log locations are:"
-    print_sources  "${monitors[@]}"
-    read -r -p "(y/n): " option
-    option=$(echo "$option" | tr -d ' ') #truncates any spaces accidentally put in
-    l="true"
-    if [ "$option" == "y" ]; then
-        while [ "$l" != "false" ]; do
-            read -r -p "Enter additional files/dirs to monitor (one entry per line; hit enter to continue): " userInput
-            if [[ "$userInput" == "" ]]; then
-                l="false"
-            else
-                log_sources+=("$userInput")
-            fi
-        done
-    fi
-    # TODO: Build out FIM with auditd. Add audit log to splunk 
-    # https://docs.rapid7.com/insightidr/fim-for-linux/
-    # https://uit.stanford.edu/service/ossec/install-source
 }
 
 function check_user {

--- a/windows/hardening/AD-Hardening.ps1
+++ b/windows/hardening/AD-Hardening.ps1
@@ -474,9 +474,9 @@ function Download-Install-Setup-Splunk {
         & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add forward-server $splunkServer
 
         # Add monitored logs based on your original script. Note: These are some general sourcetypes. You might need to adjust as per your needs.
-        & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add monitor "C:\Windows\System32\winevt\Logs\Security.evtx" -index main -sourcetype WinEventLog:Security
-        & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add monitor "C:\Windows\System32\winevt\Logs\Application.evtx" -index main -sourcetype WinEventLog:Application
-        & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add monitor "C:\Windows\System32\winevt\Logs\System.evtx" -index main -sourcetype WinEventLog:System
+        & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add monitor "C:\Windows\System32\winevt\Logs\Security.evtx" -index service_auth -sourcetype WinEventLog:Security
+        & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add monitor "C:\Windows\System32\winevt\Logs\Application.evtx" -index service -sourcetype WinEventLog:Application
+        & "$env:ProgramFiles\SplunkUniversalForwarder\bin\splunk" add monitor "C:\Windows\System32\winevt\Logs\System.evtx" -index misc -sourcetype WinEventLog:System
         # Add more logs as necessary based on the auditing you've enabled
 
         # Start Splunk forwarder service


### PR DESCRIPTION
- Revamped splunk indexer build script to be clearer and additional functionality
       - added a  line to configure receiving port during install
       - added a couple of lines that would build our searches in during install
- Revamped splunk forwarder script to have more functionality and clearness
       - broke file into multiple functions
       - attempted to add FIM but its complicated to setup and get working with splunk
       -  had to be hacky a little with the way I looped through adding indexes since some earlier bash versions dont like nested arrays
       - included ways to add new log sources to our indexes
       - general error checking
- Wrote out a SavedSearches.conf file
       - This file has our basic searches included and gives us the ability to import them during indexer install
       - more complicated searches can be typed out
- Modified windows splunk installer to reference correct indexes