### PR TITLE
tweaks from hack and destroy event

### DIFF
--- a/splunk_setup/build.sh
+++ b/splunk_setup/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+indexes=('misc' 'service_auth' 'service')
+service_monitors=( 'service' '/etc/services/' '/etc/init.d' '/var/log/apache/access.log' '/var/log/apache/error.log' '/var/log/mysql/error' '/var/www/' ) #service
+service_auth_monitors=( 'service_auth' '/var/log/auth.log' '/var/log/secure/' '/var/log/audit/audit.log' ) # service_auth
+misc_monitors=( 'misc' '/tmp' '/etc/passwd' )
 function build_indexer {
-    indexes=('misc' 'service_auth' 'service')
-    echo "Run this script as sudo user, exit and rerun if not sudo user (should be CCDCUser1). Script will begin in 3 seconds"
+
     sleep 3
     spl_url="https://download.splunk.com/products/splunk/releases/9.0.4.1/linux/splunk-9.0.4.1-419ad9369127-linux-2.6-amd64.deb"
     echo "############# Installing Splunk #############"
@@ -32,17 +35,60 @@ function build_indexer {
     sudo mkdir -p /opt/splunk/etc/users/splunk/search/local/
     sudo cp /opt/splunk/etc/users/splunk/search/local/savedsearches.conf /opt/splunk/etc/users/splunk/search/local/savedsearches.bk
     sudo mv ./savedsearches.conf /opt/splunk/etc/users/splunk/search/local/savedsearches.conf
+    echo "############# Adding Monitors #############"
+    add_monitors "${misc_monitors[@]}"
+    add_monitors "${service_auth_monitors[@]}"
+    add_monitors "${service_monitors[@]}"
     sudo /opt/splunk/bin/splunk restart
 
 }
 
-function check_user {
-    if [[ "$(whoami)" != "CCDCUser1" ]]; then
-        echo "Please run this with our privileged user"
+function add_monitors {
+    log_sources=("$@")
+    isFirst=true
+    echo "The following questions pertain to this host system....."
+    sleep 2
+    echo "Would you like to add additional log locations for index: ${log_sources[0]}"
+    echo "   -- Default log locations are:"
+    print_sources  "${log_sources[@]}"
+    read -r -p "(y/n): " option
+    option=$(echo "$option" | tr -d ' ') #truncates any spaces accidentally put in
+    l="true"
+    if [ "$option" == "y" ]; then
+        while [ "$l" != "false" ]; do
+            read -r -p "Enter additional logs sources for index: ${log_sources[0]} (one entry per line; hit enter to continue): " userInput
+            if [[ "$userInput" == "" ]]; then
+                l="false"
+            else
+                log_sources+=("$userInput")
+            fi
+        done
+    fi
+    isFirst=true
+    for source in "${log_sources[@]}"; do
+        if [ "$isFirst" = true ]; then
+            isFirst=false # ignores the name of the index and only adds the logs sources
+        else
+            sudo /opt/splunkforwarder/bin/splunk add monitor "$source" -index "${log_sources[0]}"
+        fi
+    done
+}
+
+function check_prereqs {
+    # user should not be root or run `sudo ./splunf.sh` doing so makes the splunk forwarder install be owned by root
+    if [ "$EUID" == 0 ]; then
+        echo "Please run script without sudo prefix/not as root"
         exit 1
+    fi
+
+    # check if home directory exists for current user. Home directory is needed for running splunk commands since the commands are aliases for http request methods;
+    # the .splunk directory contains this auth token so without it splunk fails to install
+    if [ ! -d /home/"$(whoami)" ]; then
+        echo "No home directory for user $(whoami). Creating home directory"
+        sudo mkdir -p /home/"$(whoami)"
     fi
 }
 
 ################## MAIN ##################
-check_user
+check_prereqs
 build_indexer

--- a/splunk_setup/savedsearches.conf
+++ b/splunk_setup/savedsearches.conf
@@ -60,7 +60,7 @@ search = index="service_auth" failed password \
 | eval other_fails=if(isnull(other_fails), 0, other_fails) \
 | eval total_fails=fails+other_fails \
 | where total_fails > 3 \
-| table fail_user, ip, total_fails
+| table hosts, fail_user, ip, total_fails
 
 [Failed Logins - Windows]
 action.webhook.enable_allowlist = 0

--- a/splunk_setup/savedsearches.conf
+++ b/splunk_setup/savedsearches.conf
@@ -56,7 +56,7 @@ search = index="service_auth" failed password \
 | rex "Failed password for invalid user (?<fail_user>[^ ]+) from (?<ip>[^ ]+)" \
 | rex "message repeated (?<num_fails>[^ ]+) times: \[ Failed password for (?<fail_user>[^ ]+) from (?<ip2>[^ ]+)" \
 | eval ip=coalesce(ip, ip2) \
-| stats values(ip) as ip, sum(num_fails) as other_fails, count as fails by fail_user \
+| stats values(host) as hosts, values(ip) as ip, sum(num_fails) as other_fails, count as fails by fail_user \
 | eval other_fails=if(isnull(other_fails), 0, other_fails) \
 | eval total_fails=fails+other_fails \
 | where total_fails > 3 \
@@ -78,7 +78,7 @@ relation = greater than
 request.ui_dispatch_app = search
 request.ui_dispatch_view = search
 search = index=service_auth source="WinEventLog:Security" EventCode=4625 \
-| stats count by Account_Name \
+| stats values(host) as hosts, count by Account_Name \
 | where count > 3
 
 [PS Activity]
@@ -97,7 +97,7 @@ relation = greater than
 request.ui_dispatch_app = search
 request.ui_dispatch_view = search
 search = index=service_auth EventCode=4104 ("PowerShell –Version" OR "-w hidden" OR "FromBase64String" OR "bypass -" OR "Invoke-") \
-| stats values(Path) as paths, values(Message) as outputs count by User 
+| stats values(host) as hosts, values(Path) as paths, values(Message) as outputs count by User 
 
 [Failed Logins Then Successful Login - Windows]
 action.webhook.enable_allowlist = 0
@@ -117,7 +117,7 @@ request.ui_dispatch_view = search
 search = index=service_auth EventCode=4625 OR EventCode=4624 NOT ("DWM*" OR "LOCAL SERVICE" OR "NETWORK SERVICE" OR "UMFD-*") \
 | eval fail=if(EventCode=4625, 1, 0) \
 | eval success=if(EventCode=4624, 1, 0) \
-| stats sum(fail) as fails, sum(success) as successes by Account_Name \
+| stats values(host) as hosts, sum(fail) as fails, sum(success) as successes by Account_Name \
 | where fails > 6 and successes > 0 
 
 

--- a/splunk_setup/splunk_win.ps1
+++ b/splunk_setup/splunk_win.ps1
@@ -1,16 +1,19 @@
 Write-Host "Please Run as an admin. CTRL + C if you are not an admin"
 Start-Sleep -Seconds 3
 $ip=$args[0]
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $indexer = $ip + ":9997"
-$securedValue = Read-Host -AsSecureString "Please enter a password for the new splunk user"
+$securedValue = Read-Host -AsSecureString "Please enter a password for the new splunk user (splunkf)"
 $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securedValue)
-$value = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+$password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
 $url = "https://download.splunk.com/products/universalforwarder/releases/9.0.1/windows/splunkforwarder-9.0.1-82c987350fde-x64-release.msi"
 $path = $(Get-Location).path + "\splunkuniversalforwarder_x86.msi"
 Write-Host "Grabbing the installer file. Downloading it to $path"
-Invoke-WebRequest -Uri $url -OutFile $path
+$wc = New-Object net.webclient
+$wc.Downloadfile($downloadURL, $path)
 write-host "The Installation will now take place in the background. The login creds should you need them are splunkf:<the password you just entered>"
 msiexec.exe /i $path SPLUNKUSERNAME=splunkf SPLUNKPASSWORD=$value RECEIVING_INDEXER=$indexer WINEVENTLOG_SEC_ENABLE=1 WINEVENTLOG_SYS_ENABLE=1 AGREETOLICENSE=Yes /quiet
 Write-Host "Setting Execution Policty back to Restricted"
 Set-ExecutionPolicy Restricted
+Start-Service SplunkForwarder
 Write-Host "DONE"


### PR DESCRIPTION
- Remove Check User
  - check if user is in a sudo group
  - make sure user isnt root
- Create home directory if one does not exist for user
  -  check if home directory exists for current user. Home directory is needed for running splunk commands since the commands are aliases for http request methods; the .splunk directory contains this auth token so without it Splunk fails to install
- added this line to windows hardening to ensure wget uses correct tls when pulling splunk
  - [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
- Splunk indexer build script
  - add host to alert queries
  - add local monitors for the Splunk indexer host itself